### PR TITLE
Removed necessity for Account when saving contact

### DIFF
--- a/contact-model.android.js
+++ b/contact-model.android.js
@@ -255,12 +255,10 @@ var Contact = (function (_super) {
         var contentResolver = appModule.android.foregroundActivity.getContentResolver();
         var ops = new java.util.ArrayList();
 
-        if (accounts.length === 0) {
-            throw new Error("No Accounts!");
+        if (accounts.length != 0) { 
+            accountName = accounts[0].name;
+            accountType = accounts[0].type;
         }
-
-        accountName = accounts[0].name;
-        accountType = accounts[0].type;
 
         if (id && id !== "") {
             var rawIdCursor = contentResolver.query(android.provider.ContactsContract.RawContacts.CONTENT_URI, ["_id"],

--- a/contact-model.android.js
+++ b/contact-model.android.js
@@ -255,7 +255,7 @@ var Contact = (function (_super) {
         var contentResolver = appModule.android.foregroundActivity.getContentResolver();
         var ops = new java.util.ArrayList();
 
-        if (accounts.length != 0) { 
+        if (accounts.length !== 0) { 
             accountName = accounts[0].name;
             accountType = accounts[0].type;
         }


### PR DESCRIPTION
As mentioned by Wern (in this issue: https://github.com/firescript/nativescript-contacts/issues/32#issuecomment-317679844), Accounts should not be needed to save a contact, so it should not throw an error. 

I simply added a conditional block around the Account related code.

