### PR TITLE
Adds missing method typing

### DIFF
--- a/nativescript-contacts.d.ts
+++ b/nativescript-contacts.d.ts
@@ -117,7 +117,7 @@ declare module "nativescript-contacts" {
         name: string;
         
         public save(useDefaultContainer: boolean);
-		public addMember(contact: Contact);
+        public addMember(contact: Contact);
     }
 
     export interface GetGroupResult {

--- a/nativescript-contacts.d.ts
+++ b/nativescript-contacts.d.ts
@@ -115,6 +115,9 @@ declare module "nativescript-contacts" {
     export class Group {
         id: string;
         name: string;
+        
+        public save(useDefaultContainer: boolean);
+		public addMember(contact: Contact);
     }
 
     export interface GetGroupResult {

--- a/nativescript-contacts.d.ts
+++ b/nativescript-contacts.d.ts
@@ -125,5 +125,5 @@ declare module "nativescript-contacts" {
         response: string; // "fetch"
     }
         
-    export function getGroups(): Promise<GetGroupResult>;
+    export function getGroups(name?: string): Promise<GetGroupResult>;
 }

--- a/nativescript-contacts.d.ts
+++ b/nativescript-contacts.d.ts
@@ -65,6 +65,7 @@ declare module "nativescript-contacts" {
         urls: ContactField[];
 
         public save();
+        public delete();
     }
 
     export var KnownLabel: {


### PR DESCRIPTION
The `delete()` method was missing from the .d.ts file, added it so it can be used from within TypeScript.