### PR TITLE
Fix path to ImageSource module

### DIFF
--- a/nativescript-contacts.d.ts
+++ b/nativescript-contacts.d.ts
@@ -1,5 +1,5 @@
 declare module "nativescript-contacts" {
-    import imageSource = require("image-source");
+    import imageSource = require("tns-core-modules/image-source");
     
     export interface ContactField {
         id?: string;


### PR DESCRIPTION
Fixes error in {N} 5.x:

```
node_modules/nativescript-contacts/nativescript-contacts.d.ts(2,31): error TS2307: Cannot find module 'image-source'.
```