### PR TITLE
Adds null check for foundGroups

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -134,7 +134,7 @@ exports.getGroups = function(name) {
       reject(error.localizedDescription);
     }
 
-    if (foundGroups.count > 0) {
+    if (foundGroups && foundGroups.count > 0) {
       var groups = [],
         i = 0,
         groupModel = null;


### PR DESCRIPTION
Doing a `getGroups()` when there are no groups returned, the following null error occurs:

```
CONSOLE ERROR file:///app/tns_modules/@angular/core/bundles/core.umd.js:15769:28: ERROR Error: Uncaught (in promise): TypeError: null is not an object (evaluating 'foundGroups.count')
file:///app/tns_modules/nativescript-contacts/index.js:137:20
```

Adding the null check prevents the error.