### PR TITLE
fix for ViewHierarchy error on iOS

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -19,7 +19,7 @@ exports.getContact = function() {
 
       var previousResult = appModule.android.onActivityResult;
 
-      appModule.android.on("activityResult", function(eventData) {
+      var handleActivityResult = function (eventData) {
         var requestCode = eventData.requestCode;
         var resultCode = eventData.resultCode;
         var data = eventData.intent;
@@ -27,6 +27,7 @@ exports.getContact = function() {
         switch (requestCode) {
           case PICK_CONTACT:
             appModule.android.onActivityResult = previousResult;
+            appModule.android.off("activityResult", handleActivityResult);
 
             if (resultCode === android.app.Activity.RESULT_OK && data != null) {
               var contentResolver = helper.getContext().getContentResolver();
@@ -67,7 +68,9 @@ exports.getContact = function() {
             }
             break;
         }
-      });
+      }
+    
+  appModule.android.on("activityResult", handleActivityResult);
 
       appModule.android.foregroundActivity.startActivityForResult(
         openContactsIntent,

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,4 @@
-var frameModule = require("ui/frame");
+const Frame = require("tns-core-modules/ui/frame").Frame;
 var Contact = require("./contact-model");
 var KnownLabel = require("./known-label");
 var Group = require("./group-model");
@@ -19,18 +19,26 @@ var CustomCNContactPickerViewControllerDelegate = NSObject.extend(
         response: "cancelled"
       });
     },
-    contactPickerDidSelectContact: function(controller, contact) {
-      controller.dismissModalViewControllerAnimated(true);
+    contactPickerDidSelectContact: function (controller, contact) {
 
-      //Convert the native contact object
-      var contactModel = new Contact();
-      contactModel.initializeFromNative(contact);
+      var self = this;
 
-      this.resolve({
-        data: contactModel,
-        response: "selected"
-      });
-      CFRelease(controller.delegate);
+      // Complete processing after view controller dismissed 
+      var completionHandler = function () {
+
+        //Convert the native contact object
+        var contactModel = new Contact();
+        contactModel.initializeFromNative(contact);
+
+        self.resolve({
+          data: contactModel,
+          response: "selected"
+        });
+        CFRelease(controller.delegate);
+      }
+ 
+      var page = Frame.topmost().ios.controller;
+      page.dismissViewControllerAnimatedCompletion(true, completionHandler);  
     }
   },
   {
@@ -49,8 +57,8 @@ exports.getContact = function() {
     CFRetain(delegate);
     controller.delegate = delegate;
 
-    var page = frameModule.topmost().ios.controller;
-    page.presentModalViewControllerAnimated(controller, true);
+    var page = Frame.topmost().ios.controller;
+    page.presentViewControllerAnimatedCompletion(controller, true, null);
   });
 };
 


### PR DESCRIPTION
index.ios.js modified to use presentViewControllerAnimatedCompletion and dismissViewControllerAnimatedCompletion so as to avoid a timing error wherein control was returned before the viewController had been dismissed, thus causing an error if the calling code attempted to display a modal dialog.  (issue #75). Also changed `frame.topmost() `invocation to remove deprecated API warning. 

index.android.js modified to correct problem where the activityResult handler was being invoked multiple times, once for each time getContact had been called.  Fix is to remove the activityResult listener via `appModule.android.off("activityResult", ...)` which in turn required putting the activityResult handler into its own function. 