### PR TITLE
fix(ios): delegate handling

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -49,7 +49,7 @@ var CustomCNContactPickerViewControllerDelegate = NSObject.extend(
 exports.getContact = function() {
   return new Promise(function(resolve, reject) {
     var controller = CNContactPickerViewController.alloc().init();
-    var delegate = CustomCNContactPickerViewControllerDelegate.alloc().initWithResolveReject(
+    var delegate = CustomCNContactPickerViewControllerDelegate.new().initWithResolveReject(
       resolve,
       reject
     );


### PR DESCRIPTION
Fixes issue with delegate construction:

```
TypeError: CustomCNContactPickerViewControllerDelegate.alloc(...).initWithResolveReject is not a function
```

The `.new()` operator should be used when extending NSObject instead of alloc().

